### PR TITLE
Add support for tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py32
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=pypy
 install:
-  - pip install -e .
+  - travis_retry pip install tox
 script:
-  - python setup.py test
+  - travis_retry tox
 branches:
   only:
     - master

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py32, py33, py34, pypy
+
+[testenv]
+deps = nose
+commands = python setup.py test


### PR DESCRIPTION
tox: http://tox.testrun.org/

    $ pip install tox
    ...
    $ tox
    ...
      py26: commands succeeded
      py27: commands succeeded
      py32: commands succeeded
      py33: commands succeeded
      py34: commands succeeded
      pypy: commands succeeded
      congratulations :)

and make `.travis.yml` use tox so that things are more DRY.