### PR TITLE
Saxbophone/8 comments

### DIFF
--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -1,7 +1,6 @@
 # encoding=UTF-8
 
 from __future__ import with_statement
-import re
 
 
 __version__ = '0.0.4'

--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -1,6 +1,7 @@
 # encoding=UTF-8
 
 from __future__ import with_statement
+import re
 
 
 __version__ = '0.0.4'
@@ -19,8 +20,17 @@ class Dotenv(dict):
             return variables
 
     def __parse_line(self, line):
-        line = line.split('#', 1)[0]
-        if line:
+        if line.lstrip().startswith('#'):
+            # discard and return nothing
+            return {}
+        if line.lstrip():
+            # find the second occurence of a quote mark:
+            quote_delimit = max(line.find('\'', line.find('\'')),
+                                line.find('"', line.rfind('"')))
+            # find first comment mark after second quote mark
+            comment_delimit = line.find('#', quote_delimit)
+            line = line[:comment_delimit]
+            print(line)
             key, value = map(lambda x: x.strip().strip('\'').strip('"'),
                              line.split('=', 1))
             return {key: value}

--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -25,12 +25,11 @@ class Dotenv(dict):
             return {}
         if line.lstrip():
             # find the second occurence of a quote mark:
-            quote_delimit = max(line.find('\'', line.find('\'')),
-                                line.find('"', line.rfind('"')))
+            quote_delimit = max(line.find('\'', line.find('\'') + 1),
+                                line.find('"', line.rfind('"')) + 1)
             # find first comment mark after second quote mark
             comment_delimit = line.find('#', quote_delimit)
             line = line[:comment_delimit]
-            print(line)
             key, value = map(lambda x: x.strip().strip('\'').strip('"'),
                              line.split('=', 1))
             return {key: value}

--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -19,9 +19,13 @@ class Dotenv(dict):
             return variables
 
     def __parse_line(self, line):
-        key, value = map(lambda x: x.strip().strip('\'').strip('"'),
-                         line.split('=', 1))
-        return {key: value}
+        line = line.split('#', 1)[0]
+        if line:
+            key, value = map(lambda x: x.strip().strip('\'').strip('"'),
+                             line.split('=', 1))
+            return {key: value}
+        else:
+            return {}
 
     def __persist(self):
         with open(self.file_path, 'w') as dotenv:

--- a/test.env
+++ b/test.env
@@ -1,0 +1,7 @@
+##############################################
+# sample test file for verifying that this thing can indeed deal with #-prefixed comments
+VAR1=65536
+VAR2=98712 # notice here a rather normal inline comment
+VAR3=#notice here a very risky inline comment!
+##############################################
+3=5#4=9793458

--- a/test.env
+++ b/test.env
@@ -1,7 +1,0 @@
-##############################################
-# sample test file for verifying that this thing can indeed deal with #-prefixed comments
-VAR1=65536
-VAR2=98712 # notice here a rather normal inline comment
-VAR3=#notice here a very risky inline comment!
-##############################################
-3=5#4=9793458

--- a/test.env
+++ b/test.env
@@ -1,0 +1,8 @@
+# a commented .env file, for testing
+SOMEVAR='12345' # a var, with an inline comment
+VAR='giggles'
+####################
+
+# another comment, notice the blank line above
+    # an indented comment
+cheese='cake'

--- a/test.env
+++ b/test.env
@@ -6,3 +6,4 @@ VAR='giggles'
 # another comment, notice the blank line above
     # an indented comment
 cheese='cake'
+COMMENT='#'

--- a/test.env
+++ b/test.env
@@ -1,9 +1,0 @@
-# a commented .env file, for testing
-SOMEVAR='12345' # a var, with an inline comment
-VAR='giggles'
-####################
-
-# another comment, notice the blank line above
-    # an indented comment
-cheese='cake'
-COMMENT='#'

--- a/tests/test_dotenv.py
+++ b/tests/test_dotenv.py
@@ -104,12 +104,15 @@ class CommentTest(CompatibilityTestCase):
     def setUp(self):
         fd, self.file_path = mkstemp()
         with open(self.file_path, 'w') as file:
-            file.write("# Commented .env file test\n")
-            file.write("FOO='bar'\n")
-            file.write("Bar=foo'\n")
-            file.write("############################!!!\n")
-            file.write("baz=1234'\n")
-            file.write("url='https://test.oi/do?it=fast' # wow look a URL!\n")
+            file.write("# a commented .env file, for testing\n")
+            file.write("SOMEVAR='12345' # a var, with an inline comment\n")
+            file.write("VAR='giggles'\n")
+            file.write("####################\n")
+            file.write("\n")
+            file.write("# another comment, notice the blank line above\n")
+            file.write("    # an indented comment\n")
+            file.write("cheese='cake'\n")
+            file.write("COMMENT='#comment#test' # a value containing a comment\n")
         self.dotenv = Dotenv(self.file_path)
 
     def tearDown(self):
@@ -120,37 +123,11 @@ class CommentTest(CompatibilityTestCase):
         self.assertIsInstance(self.dotenv, dict)
 
     def test_get_keys(self):
-        expected = set(['FOO', 'Bar', 'baz', 'url'])
+        expected = set(['SOMEVAR', 'VAR', 'cheese', 'COMMENT'])
 
         self.assertEqual(expected, set(self.dotenv.keys()))
 
     def test_get_values(self):
-        expected = set(['bar', 'foo', '1234', 'https://test.oi/do?it=fast'])
+        expected = set(['12345', 'giggles', 'cake', '#comment#test'])
 
         self.assertEqual(expected, set(self.dotenv.values()))
-
-    def test_set_new_key_value(self):
-        self.dotenv['asd'] = 'qwe'
-
-        newdotenv = Dotenv(self.file_path)
-
-        self.assertIn('asd', newdotenv)
-        self.assertEqual('qwe', newdotenv['asd'])
-
-    def test_set_existing_key(self):
-        self.dotenv['baz'] = 987
-
-        newdotenv = Dotenv(self.file_path)
-
-        self.assertEqual('987', newdotenv['baz'])
-        with open(self.file_path, 'r') as file:
-            self.assertEqual(4, len(file.readlines()))
-
-    def test_del_key(self):
-        del self.dotenv['baz']
-
-        newdotenv = Dotenv(self.file_path)
-
-        self.assertNotIn('baz', newdotenv)
-        with open(self.file_path, 'r') as file:
-            self.assertEqual(3, len(file.readlines()))


### PR DESCRIPTION
Implements the stripping out of bash-style `# comments`.
Lines that start with `#` will be ignored while lines that define a variable and also have a comment will still work, everything after the comment is ignored.