### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Python Dot Env Handler
 
 Shell Command and Library to write and read `.env` like files.
 
-[![Latest Version](https://pypip.in/version/dotenv/badge.svg)](https://pypi.python.org/pypi/dotenv/)
+[![Latest Version](https://img.shields.io/pypi/v/dotenv.svg)](https://pypi.python.org/pypi/dotenv/)
 [![Build Status](https://travis-ci.org/pedroburon/dotenv.svg?branch=master)](https://travis-ci.org/pedroburon/dotenv)
 [![Coverage Status](https://coveralls.io/repos/pedroburon/dotenv/badge.svg)](https://coveralls.io/r/pedroburon/dotenv)
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20dotenv))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `dotenv`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.